### PR TITLE
Update text on starting instance > funding source slide

### DIFF
--- a/src/components/tables/InstancesTable.vue
+++ b/src/components/tables/InstancesTable.vue
@@ -1366,7 +1366,7 @@ export default defineComponent({
           image: 'images/slide_1.jpg',
           title: 'Choose Your Funding Source',
           description:
-            'Your LNbits will use a Liquid sidechain wallet to receive bitcoin payments. You can change to another funding source in the Settings > Funding screen.'
+            'LNbits will use your selected funding source when it starts. You can configure your own external funding source in the Settings > Funding screen.'
         },
         {
           image: 'images/slide_2.jpg',

--- a/src/components/tables/InstancesTable.vue
+++ b/src/components/tables/InstancesTable.vue
@@ -355,15 +355,15 @@
             class="text-h6"
             v-text="
               isProvisioning
-                ? 'Your VPS is being provisioned...'
-                : 'Provisioned'
+                ? 'Your LNbits instance is being provisioned...'
+                : 'Provisioning complete'
             "
           ></div>
           <div
             v-text="
               isProvisioning
-                ? 'Please wait while we set up your server. This may take a few minutes.'
-                : 'Your VPS is ready!'
+                ? 'Please wait while we set up your LNbits instance. This may take a few minutes.'
+                : 'Your LNbits instance is ready!'
             "
           ></div>
         </div>


### PR DESCRIPTION
Change slide title to be more user friendly:

Before
>> Your VPS is being provisioned...

After
>> Your LNbits instance is being provisioned...

<img width="1188" height="493" alt="image" src="https://github.com/user-attachments/assets/65c5cdac-c9f0-4d39-b784-dadb393929d2" />

Change text on funding source slide to be non Liquid specific

Before
>> Your LNbits will use a Liquid sidechain wallet to receive bitcoin payments. You can change to another funding source in the Settings > Funding screen.

After
>> LNbits will use your selected funding source when it starts. You can configure your own external funding source in the Settings > Funding screen.


<img width="1379" height="160" alt="image" src="https://github.com/user-attachments/assets/0ebabf40-fdb1-4517-87c9-a7cf7944994c" />

